### PR TITLE
python 스레드 처리, spring kafka 문제 해결

### DIFF
--- a/Spring/Globa/src/main/java/org/y2k2/globa/config/KafkaConsumerConfig.java
+++ b/Spring/Globa/src/main/java/org/y2k2/globa/config/KafkaConsumerConfig.java
@@ -23,18 +23,19 @@ import org.y2k2.globa.dto.ResponseKafkaDto;
 import java.net.SocketTimeoutException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 @Configuration
 @EnableKafka
 @Slf4j
 public class KafkaConsumerConfig {
-    @Value("${kafka.bootstrap-servers}")
+    @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
-    @Value("${kafka.consumer.auto-offset-reset}")
+    @Value("${spring.kafka.consumer.auto-offset-reset}")
     private String autoOffsetReset;
-    @Value("${kafka.consumer.enable-auto-commit}")
+    @Value("${spring.kafka.consumer.enable-auto-commit}")
     private String enableAutoCommit;
-    @Value("${kafka.consumer.group-id}")
+    @Value("${spring.kafka.consumer.group-id}")
     private String groupId;
     @Value("${kafka.consumer.interval}")
     private Long interval;
@@ -46,6 +47,7 @@ public class KafkaConsumerConfig {
         Map<String, Object> consumerProperties = new HashMap<>();
         consumerProperties.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         consumerProperties.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+        consumerProperties.put(ConsumerConfig.GROUP_INSTANCE_ID_CONFIG, ("SchedulerCoordinator" + UUID.randomUUID()));
         consumerProperties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetReset);
         consumerProperties.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, enableAutoCommit);
         consumerProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -62,7 +64,7 @@ public class KafkaConsumerConfig {
         ConcurrentKafkaListenerContainerFactory<String, ResponseKafkaDto> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
         factory.setConsumerFactory(consumerFactory());
-        factory.setConcurrency(5);
+        factory.setConcurrency(1);
         factory.setCommonErrorHandler(errorHandler());
         return factory;
     }

--- a/Spring/Globa/src/main/java/org/y2k2/globa/config/KafkaProducerConfig.java
+++ b/Spring/Globa/src/main/java/org/y2k2/globa/config/KafkaProducerConfig.java
@@ -14,7 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class KafkaProducerConfig {
-    @Value("${kafka.bootstrap-servers}")
+    @Value("${spring.kafka.bootstrap-servers}")
     private String bootstrapServers;
 
     @Bean
@@ -23,7 +23,6 @@ public class KafkaProducerConfig {
         producerProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         producerProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         producerProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
-
         return new DefaultKafkaProducerFactory<>(producerProperties);
     }
 


### PR DESCRIPTION
1. thread run 메소드에서 스레드를 계속 생성해서 자원이 낭비되는 문제 해결

2. spring에서 같은 group_id로 5개의 consumer가 가입을 요청

2-1. group id가 충돌나는 문제 발생

2-2. spring은 단순 db 조회만 하기 때문에 consumer를 5개나 사용할 이유가 없음

3. member_id가 없어 계속 재가입을 시도하는 현상 발생

3-1. group_instance_id_config에 uuiod를 생성하여 해결